### PR TITLE
Added additional step to build elk stack for ARM64

### DIFF
--- a/documentation/shared/Advanced_Logging.md
+++ b/documentation/shared/Advanced_Logging.md
@@ -21,10 +21,18 @@ The task is to run the ELK stack using a docker container, to forward to the log
 
 Docker has a default setting which limits the memory resource available to the Docker Engine to 2GiB. In order to complete the following steps you will need at least 4GiB of memory allocated to Docker. To change this go to Docker -> Preferences -> Advanced -> Memory 4GiB.
 
-You can run the ELK stack by running the following command:
+To run ELK stack on a Mac, you will need to build the image for the ARM64 architecture. You can do this by cloning the elk-docker source files from the [Git repository](https://github.com/spujadas/elk-docker).
+
+Enter the directory containing the source files and run the following command to build ELK stack for ARM64:
 
 ```shell
-docker run -p 5601:5601 -p 9200:9200 -p 5044:5044 -it --name elk sebp/elk:630
+docker build -t elk-arm64 --build-arg IMAGE=master-arm64 --build-arg ARCH=aarch64 .
+```
+
+You can run ELK stack by then executing the following command:
+
+```shell
+docker run -p 5601:5601 -p 9200:9200 -p 5044:5044 -it --name elk elk-arm64
 ```
 
 Check that you can view the Kibana page on your local server [here](http://localhost:5601).

--- a/documentation/shared/Advanced_Logging.md
+++ b/documentation/shared/Advanced_Logging.md
@@ -21,19 +21,26 @@ The task is to run the ELK stack using a docker container, to forward to the log
 
 Docker has a default setting which limits the memory resource available to the Docker Engine to 2GiB. In order to complete the following steps you will need at least 4GiB of memory allocated to Docker. To change this go to Docker -> Preferences -> Advanced -> Memory 4GiB.
 
-To run ELK stack on a Mac, you will need to build the image for the ARM64 architecture. You can do this by cloning the elk-docker source files from the [Git repository](https://github.com/spujadas/elk-docker).
-
-Enter the directory containing the source files and run the following command to build ELK stack for ARM64:
+You can run ELK stack by executing the following command:
 
 ```shell
-docker build -t elk-arm64 --build-arg IMAGE=master-arm64 --build-arg ARCH=aarch64 .
+docker run -p 5601:5601 -p 9200:9200 -p 5044:5044 -it --name elk sebp/elk:630
 ```
 
-You can run ELK stack by then executing the following command:
-
-```shell
-docker run -p 5601:5601 -p 9200:9200 -p 5044:5044 -it --name elk elk-arm64
-```
+> **Note**
+>
+> If you receive the following warning: 
+> ```shell
+> WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
+> ```
+>  
+> You are on a Mac with ARM64 architecture, and will need to build the image yourself. You can do this by cloning the elk-docker source files from the [Git repository](https://github.com/spujadas/elk-docker).
+> 
+> Enter the directory containing the source files and run the following command to build ELK stack for ARM64:
+> 
+> ```shell
+> docker build -t elk-arm64 --build-arg IMAGE=master-arm64 --build-arg ARCH=aarch64 .
+> ```
 
 Check that you can view the Kibana page on your local server [here](http://localhost:5601).
 


### PR DESCRIPTION
## Description

The MacBooks provided to new joiners use the ARM64 architecture. The sebp/elk docker image is built for AMD64 and won't work if run on the Macs. Additional step was added to clone the git repo containing the elk-docker files and build it for ARM64.

## WIP

- [ ] This PR is currently a work-in-progress.
- [x] This PR is ready for review.

## Checklist

- [x] My PR includes unit or integration tests for all changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] My PR meets the acceptance criteria as outlined by my ticket.
- [x] I updated/added relevant documentation and comments (docs start with /// and comments with //).
- [x] Static analysis (e.g. Snyk) does not report any problems on my PR.

## Screenshots

Screenshots can be added here.